### PR TITLE
#14 일기 작성 페이지 벗어나면 음악 멈춤, 일기조회시 조건 추가

### DIFF
--- a/lib/create_diary_screens.dart
+++ b/lib/create_diary_screens.dart
@@ -8,7 +8,7 @@ class CreateDiaryPage extends StatefulWidget {
   _CreateDiaryPageState createState() => _CreateDiaryPageState();
 }
 
-class _CreateDiaryPageState extends State<CreateDiaryPage> {
+class _CreateDiaryPageState extends State<CreateDiaryPage> with WidgetsBindingObserver {
   final audioManager = AudioManager();
   late bool isPlaying;
   late double volume;
@@ -30,6 +30,7 @@ class _CreateDiaryPageState extends State<CreateDiaryPage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     audioManager.initAudio();
     isPlaying = audioManager.player.playing;
     volume = audioManager.player.volume;
@@ -42,6 +43,20 @@ class _CreateDiaryPageState extends State<CreateDiaryPage> {
         });
       }
     });
+  }
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    // 페이지가 dispose될 때 음악을 멈춤
+    audioManager.player.stop();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      audioManager.player.stop();
+    }
   }
 
   Future<void> _fetchUserName() async {
@@ -196,7 +211,7 @@ class _CreateDiaryPageState extends State<CreateDiaryPage> {
           // Start playing the emotion music
           playEmotionMusic(label);
 
-          // Navigate to the next page immediately
+          await playEmotionMusic(label);
           Navigator.push(
             context,
             MaterialPageRoute(

--- a/lib/date_select.dart
+++ b/lib/date_select.dart
@@ -70,7 +70,7 @@ class _DiaryNoImgPageState extends State<DiaryNoImgPage> {
 
     try {
       final response = await http.post(
-        Uri.parse('http://10.0.2.2:8080/api/diary/selectdetail'),
+        Uri.parse('http://43.203.173.116:8080/api/diary/selectdetail'),
         headers: <String, String>{
           'Content-Type': 'application/json; charset=UTF-8',
         },
@@ -98,7 +98,7 @@ class _DiaryNoImgPageState extends State<DiaryNoImgPage> {
       return;
     }
 
-    final url = Uri.parse('http://10.0.2.2:8080/api/images/diary/$diaryCode');
+    final url = Uri.parse('http://43.203.173.116:8080/api/images/diary/$diaryCode');
     try {
       final response = await http.get(url, headers: {
         'Accept': 'application/json',
@@ -128,7 +128,7 @@ class _DiaryNoImgPageState extends State<DiaryNoImgPage> {
       return;
     }
 
-    final url = Uri.parse('http://10.0.2.2:8080/api/diary/selectdetail');
+    final url = Uri.parse('http://43.203.173.116:8080/api/diary/selectdetail');
     try {
       final response = await http.post(
         url,
@@ -440,7 +440,6 @@ class _DiaryNoImgPageState extends State<DiaryNoImgPage> {
       body: Stack(
         children: [
           Container(
-            color: Color(0xFFFFF9F2),
             padding: EdgeInsets.all(16.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/home_screens.dart
+++ b/lib/home_screens.dart
@@ -175,7 +175,7 @@ class _HomePageState extends State<HomeScreens> {
         ),
       )
           .then((_) {
-        _fetchMonthlyDiaries(_focusedDay); // 새 일기 작성 후 데이터를 새로 고침
+        _fetchMonthlyDiaries(_focusedDay);
       });
     }
   }
@@ -333,7 +333,7 @@ Widget _buildCalendar() {
         }
       },
       child: Padding(
-        padding: EdgeInsets.symmetric(vertical: 8, horizontal: 30), // 날짜와 내용 전체에 적용되는 패딩
+        padding: EdgeInsets.symmetric(vertical: 8, horizontal: 30),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -364,14 +364,26 @@ Widget _buildCalendar() {
     );
   }
 
-  // 작성된 일기가 한개도 없을 때 보여줄 UI
+  // 작성된 일기가 없을 때 보여줄 UI
   Widget _buildEmptyState() {
+
+    DateTime now = DateTime.now();
+    String message;
+
+    if (_focusedDay.year == now.year && _focusedDay.month == now.month) {
+      message = '작성한 일기가 없습니다.\n일기를 작성해보세요!';
+    } else if (_focusedDay.isBefore(DateTime(now.year, now.month, 1))) {
+      message = '작성할 수 있는 기간이 지났습니다';
+    } else {
+      message = '작성할 수 있는 기간이 아닙니다';
+    }
+
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Opacity(
-            opacity: 0.5, // 투명도 설정
+            opacity: 0.5,
             child: Image.asset(
               'assets/wisely-diary-logo.png',
               height: 80,
@@ -379,7 +391,7 @@ Widget _buildCalendar() {
           ),
           SizedBox(height: 16),
           Text(
-            '작성한 일기가 없습니다.\n일기를 작성해보세요!',
+            message,
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 16,

--- a/lib/home_screens.dart
+++ b/lib/home_screens.dart
@@ -323,7 +323,15 @@ Widget _buildCalendar() {
   // 일기 항목을 생성하는 위젯
   Widget _buildDiaryEntry(String date, String content) {
     return GestureDetector(
-      onTap: () => _navigateToDiaryNoImgPage(DateTime.parse(date)),
+      onTap: () {
+        if (_hasDiary[DateTime.parse(date)] == true) {
+          // 실제 일기가 존재하는 경우에만 상세 페이지로 이동
+          _navigateToDiaryNoImgPage(DateTime.parse(date));
+        } else {
+          // 실제 일기가 없는 경우 (안내 메시지인 경우)
+          print('이 날짜에는 일기가 없습니다.');
+        }
+      },
       child: Padding(
         padding: EdgeInsets.symmetric(vertical: 8, horizontal: 30), // 날짜와 내용 전체에 적용되는 패딩
         child: Column(
@@ -356,7 +364,7 @@ Widget _buildCalendar() {
     );
   }
 
-  // 작성된 일기가 없을 때 보여줄 UI
+  // 작성된 일기가 한개도 없을 때 보여줄 UI
   Widget _buildEmptyState() {
     return Center(
       child: Column(


### PR DESCRIPTION
# 일기작성페이지, 사용자 일기 조회 수정

## 🔖 개요(작업 내용)
- 일기 작성 페이지 벗어나면 음악재생 멈춤
- 일기 내용이 없을때 나오는 안내메세지 조건 추가
- 안내 메세지를 눌렀을때 상세페이지로 이동 못하게 하는 조건 추가

## 📌 관련 이슈
<!---- 아래와 같이 Issue Number 연결 꼭 해주세요! ---->
- Resolves #14 ,#39

## 📫 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [x] 코드 중간 통합

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


## 📚 참고 사항
- 
